### PR TITLE
[MIE-1492] Too many Redis Connections

### DIFF
--- a/api/services/Caching.js
+++ b/api/services/Caching.js
@@ -37,7 +37,6 @@ module.exports = {
      * @returns {object} A Promise object that resolves with the cached data.
      */
     read: function(url) {
-        console.log('read, cache?', cacheConnected);
         if (cacheConnected === false || sails.config.cacheEnabled === false) {
             return new Promise(function(resolve, reject) {
                 return reject(200);

--- a/api/services/redisWrapper.js
+++ b/api/services/redisWrapper.js
@@ -34,29 +34,6 @@ client.on('idle', function() {
 });
 
 client.on('error', function(e) {
-    // sails.log.error('RedisClient::Events[error]: ', e);
-    if (/ECONNREFUSED/g.test(e)) {
-
-    }
+    var msg = (/ECONNREFUSED/g.test(e)) ? 'Could not connect to redis service.' : e;
+    sails.log.error('RedisClient::Events[error]: ', msg);
 });
-
-// We avoid the uncaught exception spam.
-redis.RedisClient.prototype.on_error = function (msg) {
-    var message = "Redis connection to " + this.address + " failed - " + msg;
-
-    if (this.closing) {
-        return;
-    }
-
-    if (exports.debug_mode) {
-        console.warn(message);
-    }
-
-    this.flush_and_error(message);
-
-    this.connected = false;
-    this.ready = false;
-
-    sails.log.error('Critical error. ', message);
-    //this.connection_gone("error");
-}

--- a/api/services/redisWrapper.js
+++ b/api/services/redisWrapper.js
@@ -1,0 +1,62 @@
+var
+    redis = require('redis'),
+    sails = require('sails');
+
+
+var keepAliveTick;
+
+// Countdown to send keep alive message.
+// Each time that you call it, a new countdown will replace the older one.
+var timmerKeepAlive = function(delay) {
+    if ( keepAliveTick ) clearTimeout(keepAliveTick);
+
+    keepAliveTick = setTimeout(function() {
+        if ( client.connected ) {
+            sails.log.debug('Redis was inactive for ', delay / 60 / 1000 ,' minutes. Sending keep alive.');
+            client.select(1);
+        }
+    }, delay);
+}
+
+
+client = redis.createClient(sails.config.adapters.redis.port, sails.config.adapters.redis.host, { retry_delay: 5000 });
+
+module.exports = client;
+
+
+client.on('connect',function() {
+    sails.log.debug('RedisClient::Events[connect]: [OK] Redis is up. Connections: ', client.connections);
+});
+
+client.on('idle', function() {
+    sails.log.debug('RedisClient::Events[idle].');
+    timmerKeepAlive(1000*60*4);
+});
+
+client.on('error', function(e) {
+    // sails.log.error('RedisClient::Events[error]: ', e);
+    if (/ECONNREFUSED/g.test(e)) {
+
+    }
+});
+
+// We avoid the uncaught exception spam.
+redis.RedisClient.prototype.on_error = function (msg) {
+    var message = "Redis connection to " + this.address + " failed - " + msg;
+
+    if (this.closing) {
+        return;
+    }
+
+    if (exports.debug_mode) {
+        console.warn(message);
+    }
+
+    this.flush_and_error(message);
+
+    this.connected = false;
+    this.ready = false;
+
+    sails.log.error('Critical error. ', message);
+    //this.connection_gone("error");
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "type": "git",
     "url": "git://github.com/natgeo/activitystreams.git"
   },
+  "engines" : { "node" : ">=0.8" },
   "author": "",
   "license": ""
 }


### PR DESCRIPTION
## Activity Streams creates too many Redis Connections.

Redis service dissconnects clients those who stand for 5 minutes in idle state. Then once the client detect that connection is gon, it tries to recconect and creates a new connection.

#### Changelog

- A new module redisWrapper was added in order to create a section where we could overwrite functionality from redis adpater.

- For each 4 minutes on idle state, the client will send a command queue (for instance "select(1)") what resets the idle timmer at redis service.