### PR TITLE
Add whitelist branches on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ services:
   - redis-server
 jdk:
 - openjdk7
+branches:
+  only:
+    - master
+    - develop
 notifications:
   hipchat:
     rooms:


### PR DESCRIPTION
I add a "white list branches" to avoid "build failing" with other branches under development. 