### PR TITLE
Add  keywords to controller.

### DIFF
--- a/api/controllers/ActivityController.js
+++ b/api/controllers/ActivityController.js
@@ -29,10 +29,10 @@ module.exports = {
         ];
         Activity.adapter.query(q, {}, function(err, results) {
             if (err) {
-                res.json(500, { error: 'INVALID REQUEST' });
+                return res.json(500, { error: 'INVALID REQUEST' });
             }
             res.json(results);
-            Caching.write(req, results, 1);
+            return Caching.write(req, results, 1);
         });
     },
 
@@ -73,11 +73,11 @@ module.exports = {
 
         Activity.adapter.query(q, {}, function(err, results) {
             if (err) {
-                res.json(500, { error: err, message: 'INVALID REQUEST'});
+                return res.json(500, { error: err, message: 'INVALID REQUEST'});
             }
             Activity.publishCreate({ id: actor_id, data: results[0] });
             res.json(results);
-            Caching.bust(req, results);
+            return Caching.bust(req, results);
         });
     },
 
@@ -97,14 +97,13 @@ module.exports = {
 
         Activity.adapter.query(q, {}, function(err, results) {
                 if (err) {
-                    // return res.json(err);
-                    res.json(500, { error: 'INVALID REQUEST' });
+                    return res.json(500, { error: 'INVALID REQUEST' });
                 }
                 results[0].verb = verb;
                 /** We need to update to sails 0.10.x to use publishDestroy instead of publishUpdate. */
                 Activity.publishUpdate(actor_id, {data: results[0]});
                 res.json(results);
-                Caching.bust(req);
+                return Caching.bust(req);
             }
         );
     }


### PR DESCRIPTION
Sentry is reporting hundreds of errors in the Horizon ActivityController.js file. There are two lines in particular that are causing issues, the lines with the socket publish methods in `postSpecificActivity` and `deleteSpecificActivity`.
The sentry error for both of these lines reads: "Cannot read property '0' of null."
This is most likely caused because the query to Neo-4j returns an error and when the checks for an error it sends a 500 response back to the client without returning so the rest of the code is executed and the 'results' variable is not defined.
To fix this issue, we need to simply add a `return` statement to each of the `if` blocks that check for errors in `postSpecificActivity` and `deleteSpecificActivity`.